### PR TITLE
Ignore null values during search

### DIFF
--- a/src/SortableTbl.js
+++ b/src/SortableTbl.js
@@ -40,8 +40,8 @@ class SortableTbl extends React.Component{
 		filter(e){
 			let newData = this.props.tblData.filter((item)=>{
 				for (let key in item) {
-					let v = item[key].toString().toLowerCase();
-					if (v.indexOf(e.target.value.toLowerCase()) !== -1 ) {
+					let v = item[key] && item[key].toString().toLowerCase();
+					if (v && v.indexOf(e.target.value.toLowerCase()) !== -1 ) {
 						return true;
 					}
 				}


### PR DESCRIPTION
Some fields in the table might be optional and hence might contain a
null value. This PR adds a guard so that the search doesn't throw an exception
when it encounters null values.

Thanks for the component!
- Ashima